### PR TITLE
Update cython build script to query SDK directory when on MacOS

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -25,6 +25,8 @@
 #
 
 import os
+import sys
+from subprocess import check_output
 import numpy as np
 import Cython.Compiler.Options
 Cython.Compiler.Options.annotate = True
@@ -41,6 +43,13 @@ cflags = [
     '-Wno-sometimes-uninitialized',
     os.path.expandvars('-I${CMAKE_SOURCE_DIR}/include')
 ]
+
+if sys.platform == 'darwin':
+    # when only command-line tools are installed, distutils isn't finding the
+    # MacOS SDK dir correctly. Directly query and add to flags here
+    SDKROOT = check_output(['xcrun', '--show-sdk-path']).decode('utf-8').strip()
+    # flags at end of command have precidence over earlier ones
+    cflags.append('-isysroot{}'.format(SDKROOT))
 
 ldflags = [
     os.path.expandvars('-L..'),


### PR DESCRIPTION
Ticket #12124

Workaround issue when only command-line tools are installed on MacOS 10.14 Mojave. Looks like `distutils`/`cythonize` isn't correctly resolving the `-isysroot` path to the Mac SDK directory returned by `xcrun --show-sdk-path` (though main source process does resolve `-isysroot` path). This change queries the path manually and adds it to `cflags` passed to `build_ext`.

Test case is renaming `/Applications/Xcode.app` and building.